### PR TITLE
linux fixes

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,0 +1,1 @@
+gcc -Os -s -ffunction-sections -fdata-sections src/bmxplay.c -o bmxplay -lm -lpthread

--- a/src/_xi.h
+++ b/src/_xi.h
@@ -76,7 +76,7 @@ void * _xi_init(char *msd)
 	if (msd!=NULL)
 	{
 		memcpy(&m->s, msd+4, sizeof(_xi_sample));
-		m->s.stream=(unsigned char*)(msd+4+sizeof(_xi_sample));
+		m->s.stream=(unsigned char*)(msd+4+sizeof(_xi_sample) - 8*(sizeof(void*) - 4));
 
 		size=m->s.samplelength;
 
@@ -197,7 +197,7 @@ BOOL _xi_work(_xi_machine *m, float *psamples, int numsamples, int channels)
 		if (index < length && t->play)
 		{
 			a1=s[index]; a2=s[index+1];
-			a = (a1<<8) + (a2-a1) * (t->sn & 0x000000FF);
+			a = a1*256 + (a2-a1) * (t->sn & 0x000000FF);
 
 
 			if (type!=0)

--- a/src/bmxplay.h
+++ b/src/bmxplay.h
@@ -13,6 +13,9 @@ float BmxPerfomance;		// required timeslice in %
 #define DWORD uint32_t
 #define WORD uint16_t
 #define byte uint8_t
+#define BOOL char
+#define TRUE 1
+#define FALSE 0
 #include "waveout_linux.h"
 #endif
 


### PR DESCRIPTION
I'm not sure about
```
		m->s.stream=(unsigned char*)(msd+4+sizeof(_xi_sample) - 8*(sizeof(void*) - 4));
```
this is same as 32-bit build offset, but correct fix can be:
```
		m->s.stream=(unsigned char*)(msd+4+sizeof(_xi_sample) - 2*sizeof(void*));
```
skip both pointers?
both variants much better than original, but not identical to web http://bmxplay.sourceforge.net/